### PR TITLE
fix api not defined

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -19,9 +19,11 @@ module.exports = function(impl, info, options, logger, proxy) {
     ({info, options, logger} = defaults(info, options, logger));
     let callApi = impl(info, options, logger);
     proxy = proxy || {};
-    for (let i=0; i<info.api[options.version].length; i++) {
-        let methodName = camelCase(info.api[options.version][i]);
-        proxy[methodName] = (...args) => callApi(methodName, args);
+    if (info instanceof Object && 'api' in info && options.version in info.api) {
+        for (let i = 0; i < info.api[options.version].length; i++) {
+            let methodName = camelCase(info.api[options.version][i]);
+            proxy[methodName] = (...args) => callApi(methodName, args);
+        }
     }
     
     return proxy;

--- a/test/async_test.spec.js
+++ b/test/async_test.spec.js
@@ -4,9 +4,11 @@ const {async:coroutine} = require("merapi");
 const asyncProxy = require("../async");
 
 describe("Proxy Async Test", function() {
+
+    this.timeout(5000);
     
     let container, proxy;
-    let lazyContainer, lazyProxy;
+    let lazyContainer, lazyProxy, unresolvedProxy;
 
     before(coroutine(function* () {
         container = merapi({
@@ -101,12 +103,19 @@ describe("Proxy Async Test", function() {
             return new Promise(resolve => setTimeout(resolve, ms));
         };
         yield lazyContainer.start();
-        yield sleep(1500);
+        yield sleep(2500);
         assert.equal(lazyProxy.isReady(), true);
         let res = yield lazyProxy.get(10);
         assert.deepEqual(res, 10);
     }));
 
+    it("should create proxy when version is not defined", coroutine(function* () {
+        unresolvedProxy = yield asyncProxy("http://localhost:5010", {version: "5.0.0"}, console);
+        assert.notEqual(unresolvedProxy, null);
+    }));
 
+    it("should not have any function", coroutine(function*() {
+        assert.deepEqual(Object.keys(unresolvedProxy), []);
+    }));
 
 });


### PR DESCRIPTION
Even with lazy option, sometime merapi will yield error on start when API end point cannot be accessed. Using this fix, the program will not yield any error. It will just return an empty object instead.